### PR TITLE
Raises FileNotFoundError if the keyfile is missing

### DIFF
--- a/tests/test_files_missing.py
+++ b/tests/test_files_missing.py
@@ -1,0 +1,7 @@
+import pytest
+import johnnycanencrypt as jce
+
+
+def test_missing_key():
+    with pytest.raises(FileNotFoundError):
+        j = jce.Johnny("missingfile.asc")


### PR DESCRIPTION
While creating new Jhonny object, it will raise FileNotFoundError
if the given key file is not found.