### PR TITLE
Fix docs with detailed examples

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -21,7 +21,7 @@ For the rest of the documentation we assume that you imported the module as foll
 
 
 
-.. class:: KeyStore(path: str)
+.. class:: KeyStore(path: str) -> None:
 
         Returns a KeyStore object. This is the primary class of the module, and all high level usage is available via methods of this class.
         It takes a path to the directory where it stores/reads the keys. Please make sure that only the **user** has read/write capability
@@ -38,7 +38,7 @@ For the rest of the documentation we assume that you imported the module as foll
                 >>> "HEXFINGERPRINT" in ks
 
 
-        .. method:: create_newkey(password: str, uid: str = "", ciphersuite: str = "RSA4k"):
+        .. method:: create_newkey(password: str, uid: str = "", ciphersuite: str = "RSA4k") -> Key:
 
                 Returns the public part of the newly created `Key` in the store directory. You can mention ciphersuite as *RSA2k* or *RSA4k*,
                 or *Cv25519*, while *RSA4k* is the default.
@@ -48,7 +48,7 @@ For the rest of the documentation we assume that you imported the module as foll
                         >>> ks = jce.KeyStore("/home/user/.pgpkeys")
                         >>> newkey = ks.create_newkey("supersecretpassphrasefromdiceware", "test key1 <email@example.com>", "RSA4k")
 
-        .. method:: encrypt_bytes(keys, data, outputfile="", armor=True):
+        .. method:: encrypt_bytes(keys, data, outputfile="", armor=True) -> bytes:
 
                 Encrypts the given data (either as str or bytes) via the list of keys or fingerprints. You can also just pass one single key or
                 fingerprint. If you provide *outputfile* argument with a path, the encrypted output will be written to that path. By default the
@@ -62,7 +62,7 @@ For the rest of the documentation we assume that you imported the module as foll
                         >>> encrypted = ks.encrypt_bytes([key1, key2], "Encrypted this string")
                         >>> assert encrypted.startswith(b"-----BEGIN PGP MESSAGE-----\n")
 
-        .. method:: encrypt_file(self, keys, inputfilepath, outputfilepath, armor=True):
+        .. method:: encrypt_file(self, keys, inputfilepath, outputfilepath, armor=True) -> bool:
 
                 Returns `True` after encrypting the give *inputfilepath* to the *outputfilepath*.
 
@@ -73,7 +73,7 @@ For the rest of the documentation we assume that you imported the module as foll
                         >>> key2 = ks.get_key("BB2D3F20233286371C3123D5209940B9669ED621")
                         >>> assert ks.encrypt_file([key1, key2], "/tmp/data.txt", "/tmp/data.txt.asc")
 
-        .. method:: decrypt_bytes(key, data, password=""): 
+        .. method:: decrypt_bytes(key, data, password="") -> bytes: 
 
                 Returns the decrypted bytes from the given data and the secret key. You can either pass fingerprint or a secret `Key` object
                 as the *key* argument.
@@ -90,7 +90,7 @@ For the rest of the documentation we assume that you imported the module as foll
 
                         >>> ks.decrypt_file(secret_key1, "/tmp/data.txt.asc", "/tmp/plain.txt", password=password)
 
-        .. method:: delete_key(fingerprint: str, whichkey: Union["both", "public", "secret""]="both"):
+        .. method:: delete_key(fingerprint: str, whichkey: Union["both", "public", "secret""]="both") -> None:
 
                 Deletes the given key based on the fingerprint argument, by default it removes both the public and secret key. If you only want to remove
                 the public or secret part, then pass *public* or *secret* to the **whichkey** argument.
@@ -128,20 +128,20 @@ For the rest of the documentation we assume that you imported the module as foll
                         >>> key = ks.import_cert("tests/files/store/public.asc")
                         >>> print(key)
 
-        .. method:: sign(key, data, password):
+        .. method:: sign(key, data, password) -> str:
 
                 Signs the given *data* using the secret key. Returns the armored signature string.
 
-        .. method:: sign_file(self, key, filepath, password, write=False):
+        .. method:: sign_file(self, key, filepath, password, write=False) -> str:
 
                 Returns the armored signature of the *filepath* argument using the secret key (either fingerprint or secret `Key` object).
                 If you pass *write=True*, it will also write the armored signature to a file named as *filepath.asc* 
 
-        .. method:: verify(key, data, signature):
+        .. method:: verify(key, data, signature) -> bool:
 
                 Verifies the given *data* using the public key, and signature string, returns **True** or **False** as result. 
 
-        .. method:: verify_file(key, filepath, signature_path):
+        .. method:: verify_file(key, filepath, signature_path) -> bool:
 
                 Verifies the given filepath using the public key, and signature string, returns **True** or **False** as result. 
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -10,16 +10,6 @@ For the rest of the documentation we assume that you imported the module as foll
 
 
 
-.. class:: Key(keypath: str, fingerprint: str, keytype: Union["public", "secret"])
-
-        Returns a Key object based on the keypath and fingerprint. The keytype value decides if the key object is a `public` or `secret` key. It does
-        not contain the actual key, but points to the right file path on the disk.
-
-        You can compare two key object with `==` operator.
-
-        For most of the use cases you don't have to create one manually, but you can retrive one from the `KeyStore`.
-
-
 
 .. class:: KeyStore(path: str) -> None:
 
@@ -144,5 +134,16 @@ For the rest of the documentation we assume that you imported the module as foll
         .. method:: verify_file(key, filepath, signature_path) -> bool:
 
                 Verifies the given filepath using the public key, and signature string, returns **True** or **False** as result. 
+
+
+.. class:: Key(keypath: str, fingerprint: str, keytype: Union["public", "secret"])
+
+        Returns a Key object based on the keypath and fingerprint. The keytype value decides if the key object is a `public` or `secret` key. It does
+        not contain the actual key, but points to the right file path on the disk.
+
+        You can compare two key object with `==` operator.
+
+        For most of the use cases you don't have to create one manually, but you can retrive one from the `KeyStore`.
+
 
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -15,6 +15,7 @@ is written.
    :caption: Contents:
 
    build
+   introduction
    api
    rustimplementation
 

--- a/docs/introduction.rst
+++ b/docs/introduction.rst
@@ -1,0 +1,55 @@
+Introduction to johnnycanencrypt
+================================
+
+The module has 2 parts, one high level API, which can be directly accessed via importing the module. There is another
+internal module with the same name (which is native in Rust), and has all the low level functions and classes.
+
+We will import the module as jce.
+
+::
+
+        >>> import johnnycanencrypt as jce
+
+
+The KeyStore
+-------------
+
+The module interacts over a `KeyStore` object, which points ot a directory path on the system. All keys available
+as files on that directory ending with **.pub**, or **.asc**, or **.sec**. Below is an example where we are 
+creating a keystore in an empty directory at "/home/user/.pgpkeys", and then we will import a few keys in there.
+For our example, we will use the keys from our tests directory.
+
+::
+
+        >>> ks = jce.KeyStore("/home/user/.pgpkeys")
+        >>> ks.import_cert("tests/files/store/secret.asc")
+        <Key fingerprint=BB2D3F20233286371C3123D5209940B9669ED621 keytype=secret>
+        >>> ks.import_cert("tests/files/store/pgp_keys.asc")
+        <Key fingerprint=A85FF376759C994A8A1168D8D8219C8C43F6C5E1 keytype=public>
+        >>> ks.import_cert("tests/files/store/public.asc")
+        <Key fingerprint=BB2D3F20233286371C3123D5209940B9669ED621 keytype=public>
+
+Now, if we check the directory from the shell, we will find the keys imported there.
+
+
+::
+
+        ❯ ls -l /home/user/.pgpkeys
+        .rw-rw-r--@ 9.5k user  6 Oct 18:48 A85FF376759C994A8A1168D8D8219C8C43F6C5E1.pub
+        .rw-rw-r--@ 6.2k user  6 Oct 18:48 BB2D3F20233286371C3123D5209940B9669ED621.pub
+        .rw-rw-r--@  11k user  6 Oct 18:47 BB2D3F20233286371C3123D5209940B9669ED621.sec
+
+
+Encrypting and decrypting some bytes for a given fingerprint
+-------------------------------------------------------------
+
+::
+
+        >>> key = ks.get_key("BB2D3F20233286371C3123D5209940B9669ED621")
+        >>> enc = ks.encrypt_bytes(key, "Sequoia is amazing.")
+        >>> print(enc[:27])
+        b'-----BEGIN PGP MESSAGE-----'
+        >>> secret_key = ks.get_key("BB2D3F20233286371C3123D5209940B9669ED621", "secret")
+        >>> text = ks.decrypt_bytes(secret_key, enc, "redhat")
+        >>> print(text)
+        b'Sequoia is amazing.'


### PR DESCRIPTION
We now have one `introduction` chapter in the docs.