### PR TITLE
Modified hardcoded tests paths so that tests can be run whatever cwd is

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,11 +1,15 @@
+from pathlib import Path
+
 import pytest
 
 from .utils import clean_outputfiles
 
+BASE_TESTSDIR = Path(__file__).parent
+
 
 @pytest.fixture()
 def encrypt_decrypt_file():
-    inputfile = "tests/files/text.txt"
+    inputfile = BASE_TESTSDIR / "files/text.txt"
     output = "/tmp/text-encrypted.pgp"
     decrypted_output = "/tmp/text.txt"
     clean_outputfiles(output, decrypted_output)

--- a/tests/test_encrypt_decrypt.py
+++ b/tests/test_encrypt_decrypt.py
@@ -2,6 +2,7 @@ import os
 
 import johnnycanencrypt.johnnycanencrypt as jce
 
+from .conftest import BASE_TESTSDIR
 from .utils import _get_cert_data
 
 DATA = "Kushal loves 🦀"
@@ -31,7 +32,7 @@ def test_encryption_of_multiple_keys_to_files():
     if os.path.exists(output):
         os.remove(output)
     certs = []
-    for keyfilename in ["tests/files/public.asc", "tests/files/hellopublic.asc"]:
+    for keyfilename in [BASE_TESTSDIR / "files/public.asc", BASE_TESTSDIR / "files/hellopublic.asc"]:
         certs.append(_get_cert_data(keyfilename))
     jce.encrypt_bytes_to_file(
         certs,
@@ -43,34 +44,34 @@ def test_encryption_of_multiple_keys_to_files():
     # Now let us decrypt it via first secret key
     with open(output, "rb") as f:
         enc = f.read()
-    jp = jce.Johnny(_get_cert_data("tests/files/hellosecret.asc"))
+    jp = jce.Johnny(_get_cert_data(BASE_TESTSDIR / "files/hellosecret.asc"))
     result = jp.decrypt_bytes(enc, "redhat")
     assert DATA == result.decode("utf-8")
 
-    jp = jce.Johnny(_get_cert_data("tests/files/secret.asc"))
+    jp = jce.Johnny(_get_cert_data(BASE_TESTSDIR / "files/secret.asc"))
     result = jp.decrypt_bytes(enc, "redhat")
     assert DATA == result.decode("utf-8")
 
 
 def test_encryption_of_multiple_keys_of_a_file():
     "Encrypt bytes to a file using multiple keys"
-    inputfile = "tests/files/text.txt"
+    inputfile = BASE_TESTSDIR / "files/text.txt"
     output = "/tmp/text-encrypted.pgp"
     decrypted_output = "/tmp/text.txt"
     clean_outputfiles(output, decrypted_output)
     certs = []
-    for keyfilename in ["tests/files/public.asc", "tests/files/hellopublic.asc"]:
+    for keyfilename in [BASE_TESTSDIR / "files/public.asc", BASE_TESTSDIR / "files/hellopublic.asc"]:
         certs.append(_get_cert_data(keyfilename))
 
     jce.encrypt_file_internal(
         certs,
-        inputfile.encode("utf-8"),
+        inputfile.as_posix().encode("utf-8"),
         output.encode("utf-8"),
         armor=True,
     )
     assert os.path.exists(output)
     # Now let us decrypt it via second secret key
-    jp = jce.Johnny(_get_cert_data("tests/files/hellosecret.asc"))
+    jp = jce.Johnny(_get_cert_data(BASE_TESTSDIR / "files/hellosecret.asc"))
     assert jp.decrypt_file(
         output.encode("utf-8"), decrypted_output.encode("utf-8"), "redhat"
     )
@@ -80,7 +81,7 @@ def test_encryption_of_multiple_keys_of_a_file():
     os.remove(decrypted_output)
 
     # Via first secret key
-    jp = jce.Johnny(_get_cert_data("tests/files/secret.asc"))
+    jp = jce.Johnny(_get_cert_data(BASE_TESTSDIR / "files/secret.asc"))
     assert jp.decrypt_file(
         output.encode("utf-8"), decrypted_output.encode("utf-8"), "redhat"
     )
@@ -90,7 +91,7 @@ def test_encryption_of_multiple_keys_of_a_file():
 def test_encryption_of_multiple_keys_to_bytes():
     "Encrypt bytes using multiple keys"
     certs = []
-    for keyfilename in ["tests/files/public.asc", "tests/files/hellopublic.asc"]:
+    for keyfilename in [BASE_TESTSDIR / "files/public.asc", BASE_TESTSDIR / "files/hellopublic.asc"]:
         certs.append(_get_cert_data(keyfilename))
     encrypted = jce.encrypt_bytes_to_bytes(
         certs,
@@ -98,45 +99,45 @@ def test_encryption_of_multiple_keys_to_bytes():
         armor=True,
     )
     # Now let us decrypt it via first secret key
-    jp = jce.Johnny(_get_cert_data("tests/files/hellosecret.asc"))
+    jp = jce.Johnny(_get_cert_data(BASE_TESTSDIR / "files/hellosecret.asc"))
     result = jp.decrypt_bytes(encrypted, "redhat")
     assert DATA == result.decode("utf-8")
 
-    jp = jce.Johnny(_get_cert_data("tests/files/secret.asc"))
+    jp = jce.Johnny(_get_cert_data(BASE_TESTSDIR / "files/secret.asc"))
     result = jp.decrypt_bytes(encrypted, "redhat")
     assert DATA == result.decode("utf-8")
 
 
 def test_encrypt_decrypt_bytes():
     "Tests raw bytes as output"
-    jp = jce.Johnny(_get_cert_data("tests/files/public.asc"))
+    jp = jce.Johnny(_get_cert_data(BASE_TESTSDIR / "files/public.asc"))
     enc = jp.encrypt_bytes(DATA.encode("utf-8"))
-    jp = jce.Johnny(_get_cert_data("tests/files/secret.asc"))
+    jp = jce.Johnny(_get_cert_data(BASE_TESTSDIR / "files/secret.asc"))
     result = jp.decrypt_bytes(enc, "redhat")
     assert DATA == result.decode("utf-8")
 
 
 def test_encrypt_decrypt_bytes_armored():
     "Tests ascii-armored output"
-    j = jce.Johnny(_get_cert_data("tests/files/public.asc"))
+    j = jce.Johnny(_get_cert_data(BASE_TESTSDIR / "files/public.asc"))
     enc = j.encrypt_bytes(DATA.encode("utf-8"), armor=True)
     assert enc.startswith(b"-----BEGIN PGP MESSAGE-----")
-    jp = jce.Johnny(_get_cert_data("tests/files/secret.asc"))
+    jp = jce.Johnny(_get_cert_data(BASE_TESTSDIR / "files/secret.asc"))
     result = jp.decrypt_bytes(enc, "redhat")
     assert DATA == result.decode("utf-8")
 
 
 def test_encrypt_decrypt_files():
     "Tests encrypt/decrypt file in binary format"
-    inputfile = "tests/files/text.txt"
+    inputfile = BASE_TESTSDIR / "files/text.txt"
     output = "/tmp/text-encrypted.pgp"
     decrypted_output = "/tmp/text.txt"
     clean_outputfiles(output, decrypted_output)
 
     # Now encrypt and then decrypt
-    j = jce.Johnny(_get_cert_data("tests/files/public.asc"))
-    assert j.encrypt_file(inputfile.encode("utf-8"), output.encode("utf-8"))
-    jp = jce.Johnny(_get_cert_data("tests/files/secret.asc"))
+    j = jce.Johnny(_get_cert_data(BASE_TESTSDIR / "files/public.asc"))
+    assert j.encrypt_file(inputfile.as_posix().encode("utf-8"), output.encode("utf-8"))
+    jp = jce.Johnny(_get_cert_data(BASE_TESTSDIR / "files/secret.asc"))
     assert jp.decrypt_file(
         output.encode("utf-8"), decrypted_output.encode("utf-8"), "redhat"
     )
@@ -145,15 +146,15 @@ def test_encrypt_decrypt_files():
 
 
 def test_encrypt_decrypt_files_armored():
-    inputfile = "tests/files/text.txt"
+    inputfile = BASE_TESTSDIR / "files/text.txt"
     output = "/tmp/text-encrypted.asc"
     decrypted_output = "/tmp/text.txt"
     clean_outputfiles(output, decrypted_output)
 
     # Now encrypt and then decrypt
-    j = jce.Johnny(_get_cert_data("tests/files/public.asc"))
-    assert j.encrypt_file(inputfile.encode("utf-8"), output.encode("utf-8"), armor=True)
-    jp = jce.Johnny(_get_cert_data("tests/files/secret.asc"))
+    j = jce.Johnny(_get_cert_data(BASE_TESTSDIR / "files/public.asc"))
+    assert j.encrypt_file(inputfile.as_posix().encode("utf-8"), output.encode("utf-8"), armor=True)
+    jp = jce.Johnny(_get_cert_data(BASE_TESTSDIR / "files/secret.asc"))
     assert jp.decrypt_file(
         output.encode("utf-8"), decrypted_output.encode("utf-8"), "redhat"
     )
@@ -173,22 +174,22 @@ def test_encrypt_decrypt_files_armored():
 # ❯ cp double.asc ../rust/johnnycanencrypt/tests/files/double_recipient.asc
 # Test case for issue number #14
 def test_decrypt_multiple_recipient_data():
-    with open("tests/files/double_recipient.asc", "rb") as f:
+    with open(BASE_TESTSDIR / "files/double_recipient.asc", "rb") as f:
         data = f.read()
 
-    jp = jce.Johnny(_get_cert_data("tests/files/secret.asc"))
+    jp = jce.Johnny(_get_cert_data(BASE_TESTSDIR / "files/secret.asc"))
     cleartext = jp.decrypt_bytes(data, "redhat")
     assert cleartext == b"Hello World! for 2.\n"
 
 
 def test_encryption_of_multiple_keys_of_a_filehandler():
     "Encrypt bytes to an opened file using multiple keys"
-    inputfile = "tests/files/text.txt"
+    inputfile = BASE_TESTSDIR / "files/text.txt"
     output = "/tmp/text-encrypted2.pgp"
     decrypted_output = "/tmp/text2.txt"
     clean_outputfiles(output, decrypted_output)
     certs = []
-    for keyfilename in ["tests/files/public.asc", "tests/files/hellopublic.asc"]:
+    for keyfilename in [BASE_TESTSDIR / "files/public.asc", BASE_TESTSDIR / "files/hellopublic.asc"]:
         certs.append(_get_cert_data(keyfilename))
 
     with open(inputfile, "rb") as fobj:
@@ -200,7 +201,7 @@ def test_encryption_of_multiple_keys_of_a_filehandler():
         )
     assert os.path.exists(output)
     # Now let us decrypt it via second secret key
-    jp = jce.Johnny(_get_cert_data("tests/files/hellosecret.asc"))
+    jp = jce.Johnny(_get_cert_data(BASE_TESTSDIR / "files/hellosecret.asc"))
     with open(output, "rb") as fobj:
         assert jp.decrypt_filehandler(fobj, decrypted_output.encode("utf-8"), "redhat")
     verify_files(inputfile, decrypted_output)
@@ -209,7 +210,7 @@ def test_encryption_of_multiple_keys_of_a_filehandler():
     os.remove(decrypted_output)
 
     # Via first secret key
-    jp = jce.Johnny(_get_cert_data("tests/files/secret.asc"))
+    jp = jce.Johnny(_get_cert_data(BASE_TESTSDIR / "files/secret.asc"))
     with open(output, "rb") as fobj:
         assert jp.decrypt_filehandler(fobj, decrypted_output.encode("utf-8"), "redhat")
     verify_files(inputfile, decrypted_output)

--- a/tests/test_keystore.py
+++ b/tests/test_keystore.py
@@ -11,6 +11,7 @@ from pprint import pprint
 import johnnycanencrypt as jce
 import johnnycanencrypt.johnnycanencrypt as rjce
 
+from .conftest import BASE_TESTSDIR
 from .utils import clean_outputfiles, verify_files
 
 DATA = "Kushal loves 🦀"
@@ -25,17 +26,17 @@ def teardown_module(module):
 
 
 def test_correct_keystore_path():
-    ks = jce.KeyStore("tests/files/store")
+    ks = jce.KeyStore(BASE_TESTSDIR / "files/store")
 
 
 def test_nonexisting_keystore_path():
     with pytest.raises(OSError):
-        ks = jce.KeyStore("tests/files2/")
+        ks = jce.KeyStore(BASE_TESTSDIR / "files2/")
 
 
 def test_no_such_key():
     with pytest.raises(jce.KeyNotFoundError):
-        ks = jce.KeyStore("tests/files/store")
+        ks = jce.KeyStore(BASE_TESTSDIR / "files/store")
         key = ks.get_key("A4F388BBB194925AE301F844C52B42177857DD79")
 
 
@@ -47,10 +48,10 @@ def test_keystore_lifecycle():
     # the default key must be of secret
     assert newkey.keytype == jce.KeyType.SECRET
 
-    ks.import_cert("tests/files/store/public.asc")
-    ks.import_cert("tests/files/store/pgp_keys.asc")
-    ks.import_cert("tests/files/store/hellopublic.asc")
-    ks.import_cert("tests/files/store/secret.asc")
+    ks.import_cert((BASE_TESTSDIR / "files/store/public.asc").as_posix())
+    ks.import_cert((BASE_TESTSDIR / "files/store/pgp_keys.asc").as_posix())
+    ks.import_cert((BASE_TESTSDIR / "files/store/hellopublic.asc").as_posix())
+    ks.import_cert((BASE_TESTSDIR / "files/store/secret.asc").as_posix())
     # Now check the numbers of keys in the store
     assert (2, 2) == ks.details()
 
@@ -75,9 +76,9 @@ def test_keystore_lifecycle():
 def test_keystore_contains_key():
     "verifies __contains__ method for keystore"
     ks = jce.KeyStore(tmpdirname.name)
-    keypath = "tests/files/store/secret.asc"
-    k = ks.import_cert(keypath)
-    _, fingerprint, keytype, exp, ctime, othervalues = jce.parse_cert_file(keypath)
+    keypath = BASE_TESTSDIR / "files/store/secret.asc"
+    k = ks.import_cert(keypath.as_posix())
+    _, fingerprint, keytype, exp, ctime, othervalues = jce.parse_cert_file(keypath.as_posix())
 
     # First only the fingerprint
     assert fingerprint in ks
@@ -88,18 +89,18 @@ def test_keystore_contains_key():
 
 
 def test_keystore_details():
-    ks = jce.KeyStore("./tests/files/store")
+    ks = jce.KeyStore(BASE_TESTSDIR / "files/store")
     assert (1, 2) == ks.details()
 
 
 def test_keystore_keyids():
-    ks = jce.KeyStore("./tests/files/store")
+    ks = jce.KeyStore(BASE_TESTSDIR / "files/store")
     key = ks.get_key("A85FF376759C994A8A1168D8D8219C8C43F6C5E1")
     assert key.keyid == "D8219C8C43F6C5E1"
 
 
 def test_keystore_get_via_keyids():
-    ks = jce.KeyStore("./tests/files/store")
+    ks = jce.KeyStore(BASE_TESTSDIR / "files/store")
     key = ks.get_key("A85FF376759C994A8A1168D8D8219C8C43F6C5E1")
     keys = ks.get_keys_by_keyid("FB82AA5D326DA75D")
     assert len(keys) == 1
@@ -107,7 +108,7 @@ def test_keystore_get_via_keyids():
 
 
 def test_keystore_key_uids():
-    ks = jce.KeyStore("./tests/files/store")
+    ks = jce.KeyStore(BASE_TESTSDIR / "files/store")
     key = ks.get_key("A85FF376759C994A8A1168D8D8219C8C43F6C5E1")
     assert "kushal@fedoraproject.org" == key.uids[0]["email"]
     assert "mail@kushaldas.in" == key.uids[-1]["email"]
@@ -116,7 +117,7 @@ def test_keystore_key_uids():
 def test_key_password_change():
     tempdir = tempfile.TemporaryDirectory()
     ks = jce.KeyStore(tempdir.name)
-    k = ks.import_cert("tests/files/store/secret.asc")
+    k = ks.import_cert((BASE_TESTSDIR / "files/store/secret.asc").as_posix())
     k2 = ks.update_password(k, "redhat", "byebye")
     data = ks.sign(k2, b"hello", "byebye")
 
@@ -124,11 +125,11 @@ def test_key_password_change():
 def test_key_deletion():
     tempdir = tempfile.TemporaryDirectory()
     ks = jce.KeyStore(tempdir.name)
-    ks.import_cert("tests/files/store/public.asc")
-    k = ks.import_cert("tests/files/store/pgp_keys.asc")
-    ks.import_cert("tests/files/store/hellopublic.asc")
-    ks.import_cert("tests/files/store/hellosecret.asc")
-    ks.import_cert("tests/files/store/secret.asc")
+    ks.import_cert((BASE_TESTSDIR / "files/store/public.asc").as_posix())
+    k = ks.import_cert((BASE_TESTSDIR / "files/store/pgp_keys.asc").as_posix())
+    ks.import_cert((BASE_TESTSDIR / "files/store/hellopublic.asc").as_posix())
+    ks.import_cert((BASE_TESTSDIR / "files/store/hellosecret.asc").as_posix())
+    ks.import_cert((BASE_TESTSDIR / "files/store/secret.asc").as_posix())
     assert (1, 2) == ks.details()
 
     ks.delete_key("F4F388BBB194925AE301F844C52B42177857DD79")
@@ -146,7 +147,7 @@ def test_key_deletion():
 
 
 def test_key_equality():
-    ks = jce.KeyStore("tests/files/store")
+    ks = jce.KeyStore(BASE_TESTSDIR / "files/store")
     key = ks.get_key("F51C310E02DC1B7771E176D8A1C5C364EB5B9A20")
     assert key.fingerprint == "F51C310E02DC1B7771E176D8A1C5C364EB5B9A20"
 
@@ -155,8 +156,8 @@ def test_ks_update_expiry_time_for_subkeys():
     "Updates expiry time for a given subkey"
     tempdir = tempfile.TemporaryDirectory()
     ks = jce.KeyStore(tempdir.name)
-    ks.import_cert("tests/files/store/hellosecret.asc")
-    ks.import_cert("tests/files/store/secret.asc")
+    ks.import_cert((BASE_TESTSDIR / "files/store/hellosecret.asc").as_posix())
+    ks.import_cert((BASE_TESTSDIR / "files/store/secret.asc").as_posix())
 
     key = ks.get_key("F4F388BBB194925AE301F844C52B42177857DD79")
     subkeys = [
@@ -175,7 +176,7 @@ def test_ks_update_expiry_time_for_subkeys():
 
 def test_ks_encrypt_decrypt_bytes():
     "Encrypts and decrypt some bytes"
-    ks = jce.KeyStore("tests/files/store")
+    ks = jce.KeyStore(BASE_TESTSDIR / "files/store")
     public_key = ks.get_key("F51C310E02DC1B7771E176D8A1C5C364EB5B9A20")
     encrypted = ks.encrypt(public_key, DATA)
     assert encrypted.startswith(b"-----BEGIN PGP MESSAGE-----\n")
@@ -188,7 +189,7 @@ def test_ks_encrypt_decrypt_bytes():
 
 def test_ks_encrypt_decrypt_bytes_multiple_recipients():
     "Encrypts and decrypt some bytes"
-    ks = jce.KeyStore("tests/files/store")
+    ks = jce.KeyStore(BASE_TESTSDIR / "files/store")
     key1 = ks.get_key("F51C310E02DC1B7771E176D8A1C5C364EB5B9A20")
     key2 = ks.get_key("F4F388BBB194925AE301F844C52B42177857DD79")
     encrypted = ks.encrypt([key1, key2], DATA)
@@ -208,7 +209,7 @@ def test_ks_encrypt_decrypt_bytes_multiple_recipients():
 def test_ks_encrypt_decrypt_bytes_to_file():
     "Encrypts and decrypt some bytes"
     outputfile = os.path.join(tmpdirname.name, "encrypted.asc")
-    ks = jce.KeyStore("tests/files/store")
+    ks = jce.KeyStore(BASE_TESTSDIR / "files/store")
     secret_key = ks.get_key("F51C310E02DC1B7771E176D8A1C5C364EB5B9A20")
     assert ks.encrypt(secret_key, DATA, outputfile=outputfile)
     with open(outputfile, "rb") as fobj:
@@ -223,7 +224,7 @@ def test_ks_encrypt_decrypt_bytes_to_file():
 def test_ks_encrypt_decrypt_bytes_to_file_multiple_recipients():
     "Encrypts and decrypt some bytes"
     outputfile = os.path.join(tmpdirname.name, "encrypted.asc")
-    ks = jce.KeyStore("tests/files/store")
+    ks = jce.KeyStore(BASE_TESTSDIR / "files/store")
     key1 = ks.get_key("F51C310E02DC1B7771E176D8A1C5C364EB5B9A20")
     key2 = ks.get_key("F4F388BBB194925AE301F844C52B42177857DD79")
     assert ks.encrypt([key1, key2], DATA, outputfile=outputfile)
@@ -238,13 +239,13 @@ def test_ks_encrypt_decrypt_bytes_to_file_multiple_recipients():
 
 def test_ks_encrypt_decrypt_file(encrypt_decrypt_file):
     "Encrypts and decrypt some bytes"
-    inputfile = "tests/files/text.txt"
+    inputfile = BASE_TESTSDIR / "files/text.txt"
     output = "/tmp/text-encrypted.pgp"
     decrypted_output = "/tmp/text.txt"
 
-    ks = jce.KeyStore("tests/files/store")
+    ks = jce.KeyStore(BASE_TESTSDIR / "files/store")
     public_key = ks.get_key("F51C310E02DC1B7771E176D8A1C5C364EB5B9A20")
-    assert ks.encrypt_file(public_key, inputfile, output)
+    assert ks.encrypt_file(public_key, inputfile.as_posix(), output)
     secret_key = ks.get_key("F51C310E02DC1B7771E176D8A1C5C364EB5B9A20")
     ks.decrypt_file(secret_key, output, decrypted_output, password="redhat")
     verify_files(inputfile, decrypted_output)
@@ -252,11 +253,11 @@ def test_ks_encrypt_decrypt_file(encrypt_decrypt_file):
 
 def test_ks_encrypt_decrypt_filehandler(encrypt_decrypt_file):
     "Encrypts and decrypt some bytes"
-    inputfile = "tests/files/text.txt"
+    inputfile = BASE_TESTSDIR / "files/text.txt"
     output = "/tmp/text-encrypted.pgp"
     decrypted_output = "/tmp/text.txt"
 
-    ks = jce.KeyStore("tests/files/store")
+    ks = jce.KeyStore(BASE_TESTSDIR / "files/store")
     public_key = ks.get_key("F51C310E02DC1B7771E176D8A1C5C364EB5B9A20")
     with open(inputfile, "rb") as fobj:
         assert ks.encrypt_file(public_key, fobj, output)
@@ -268,14 +269,14 @@ def test_ks_encrypt_decrypt_filehandler(encrypt_decrypt_file):
 
 def test_ks_encrypt_decrypt_file_multiple_recipients(encrypt_decrypt_file):
     "Encrypts and decrypt some bytes"
-    inputfile = "tests/files/text.txt"
+    inputfile = BASE_TESTSDIR / "files/text.txt"
     output = "/tmp/text-encrypted.pgp"
     decrypted_output = "/tmp/text.txt"
 
-    ks = jce.KeyStore("tests/files/store")
+    ks = jce.KeyStore(BASE_TESTSDIR / "files/store")
     key1 = ks.get_key("F51C310E02DC1B7771E176D8A1C5C364EB5B9A20")
     key2 = ks.get_key("F4F388BBB194925AE301F844C52B42177857DD79")
-    encrypted = ks.encrypt_file([key1, key2], inputfile, output)
+    encrypted = ks.encrypt_file([key1, key2], inputfile.as_posix(), output)
     secret_key1 = ks.get_key("F51C310E02DC1B7771E176D8A1C5C364EB5B9A20")
     ks.decrypt_file(secret_key1, output, decrypted_output, password="redhat")
     verify_files(inputfile, decrypted_output)
@@ -285,7 +286,7 @@ def test_ks_encrypt_decrypt_file_multiple_recipients(encrypt_decrypt_file):
 
 
 def test_ks_sign_data():
-    ks = jce.KeyStore("tests/files/store")
+    ks = jce.KeyStore(BASE_TESTSDIR / "files/store")
     key = "F51C310E02DC1B7771E176D8A1C5C364EB5B9A20"
     signed = ks.sign(key, "hello", "redhat")
     assert signed.startswith("-----BEGIN PGP SIGNATURE-----\n")
@@ -293,7 +294,7 @@ def test_ks_sign_data():
 
 
 def test_ks_sign_data_fails():
-    ks = jce.KeyStore("tests/files/store")
+    ks = jce.KeyStore(BASE_TESTSDIR / "files/store")
     key = "F51C310E02DC1B7771E176D8A1C5C364EB5B9A20"
     signed = ks.sign(key, "hello", "redhat")
     assert signed.startswith("-----BEGIN PGP SIGNATURE-----\n")
@@ -301,10 +302,10 @@ def test_ks_sign_data_fails():
 
 
 def test_ks_sign_verify_file():
-    inputfile = "tests/files/text.txt"
+    inputfile = BASE_TESTSDIR / "files/text.txt"
     tempdir = tempfile.TemporaryDirectory()
     shutil.copy(inputfile, tempdir.name)
-    ks = jce.KeyStore("tests/files/store")
+    ks = jce.KeyStore(BASE_TESTSDIR / "files/store")
     key = "F51C310E02DC1B7771E176D8A1C5C364EB5B9A20"
     file_to_be_signed = os.path.join(tempdir.name, "text.txt")
     signed = ks.sign_file(key, file_to_be_signed, "redhat", write=True)
@@ -321,9 +322,9 @@ def test_ks_creation_expiration_time():
     ctime = datetime.datetime(2017, 10, 17, 20, 53, 47)
     tmpdir = tempfile.TemporaryDirectory()
     # First let us check from the file
-    keypath = "tests/files/store/pgp_keys.asc"
+    keypath = BASE_TESTSDIR / "files/store/pgp_keys.asc"
     ks = jce.KeyStore(tmpdir.name)
-    k = ks.import_cert(keypath)
+    k = ks.import_cert(keypath.as_posix())
     assert etime.date() == k.expirationtime.date()
     assert ctime.date() == k.creationtime.date()
 
@@ -372,7 +373,7 @@ def test_ks_creation_expiration_time():
 
 
 def test_get_all_keys():
-    ks = jce.KeyStore("./tests/files/store")
+    ks = jce.KeyStore(BASE_TESTSDIR / "files/store")
     keys = ks.get_all_keys()
     assert 3 == len(keys)
     # TODO: add more checks here in future
@@ -380,7 +381,7 @@ def test_get_all_keys():
 
 def test_get_pub_key():
     """Verifies that we export only the public key part from any key"""
-    ks = jce.KeyStore("./tests/files/store")
+    ks = jce.KeyStore(BASE_TESTSDIR / "files/store")
     fingerprint = "F51C310E02DC1B7771E176D8A1C5C364EB5B9A20"
     key = ks.get_key(fingerprint)
     # verify that the key is a secret
@@ -395,7 +396,7 @@ def test_add_userid():
     """Verifies that we can add uid to a cert"""
     tempdir = tempfile.TemporaryDirectory()
     ks = jce.KeyStore(tempdir.name)
-    key = ks.import_cert("tests/files/store/secret.asc")
+    key = ks.import_cert((BASE_TESTSDIR / "files/store/secret.asc").as_posix())
     # check that there is only one userid
     assert len(key.uids) == 1
 
@@ -411,7 +412,7 @@ def test_add_and_revoke_userid():
     """Verifies that we can add uid to a cert"""
     tempdir = tempfile.TemporaryDirectory()
     ks = jce.KeyStore(tempdir.name)
-    key = ks.import_cert("tests/files/store/secret.asc")
+    key = ks.import_cert((BASE_TESTSDIR / "files/store/secret.asc").as_posix())
     # check that there is only one userid
     assert len(key.uids) == 1
 
@@ -442,7 +443,7 @@ def test_add_userid_fails_for_public():
     """Verifies that adding uid to a public key fails"""
     tempdir = tempfile.TemporaryDirectory()
     ks = jce.KeyStore(tempdir.name)
-    key = ks.import_cert("tests/files/store/public.asc")
+    key = ks.import_cert((BASE_TESTSDIR / "files/store/public.asc").as_posix())
     # verify that the key is a secret
     assert len(key.uids) == 1
 
@@ -453,7 +454,7 @@ def test_add_userid_fails_for_public():
 
 def test_update_subkey_expiry_time():
     "Updates the expirytime for a given subkey"
-    ks = jce.KeyStore("tests/files/store")
+    ks = jce.KeyStore(BASE_TESTSDIR / "files/store")
     key = ks.get_key("F4F388BBB194925AE301F844C52B42177857DD79")
     fps = [
         "102EBD23BD5D2D340FBBDE0ADFD1C55926648D2F",
@@ -472,9 +473,9 @@ def test_update_subkey_expiry_time():
 def test_same_key_import_error():
     tempdir = tempfile.TemporaryDirectory()
     ks = jce.KeyStore(tempdir.name)
-    ks.import_cert("tests/files/store/public.asc")
+    ks.import_cert((BASE_TESTSDIR / "files/store/public.asc").as_posix())
     with pytest.raises(jce.CryptoError):
-        ks.import_cert("tests/files/store/public.asc")
+        ks.import_cert((BASE_TESTSDIR / "files/store/public.asc").as_posix())
 
 
 def test_key_without_uid():
@@ -501,7 +502,7 @@ def test_key_with_multiple_uids():
 def test_ks_upgrade():
     "tests db upgrade from an old db"
     tempdir = tempfile.TemporaryDirectory()
-    shutil.copy("tests/files/store/oldjce.db", os.path.join(tempdir.name, "jce.db"))
+    shutil.copy(BASE_TESTSDIR / "files/store/oldjce.db", os.path.join(tempdir.name, "jce.db"))
     ks = jce.KeyStore(tempdir.name)
     con = sqlite3.connect(ks.dbpath)
     con.row_factory = sqlite3.Row
@@ -517,25 +518,25 @@ def test_ks_upgrade():
 def test_ks_upgrade_failure():
     "tests db upgrade failure from an old db because of existing file"
     tempdir = tempfile.TemporaryDirectory()
-    shutil.copy("tests/files/store/oldjce.db", os.path.join(tempdir.name, "jce.db"))
+    shutil.copy(BASE_TESTSDIR / "files/store/oldjce.db", os.path.join(tempdir.name, "jce.db"))
     shutil.copy(
-        "tests/files/store/oldjce.db", os.path.join(tempdir.name, "jce_upgrade.db")
+        BASE_TESTSDIR / "files/store/oldjce.db", os.path.join(tempdir.name, "jce_upgrade.db")
     )
     with pytest.raises(RuntimeError):
         ks = jce.KeyStore(tempdir.name)
 
 
 def test_get_encrypted_for():
-    ks = jce.KeyStore("tests/files/store/")
-    keyids = rjce.file_encrypted_for("tests/files/double_recipient.asc")
+    ks = jce.KeyStore(BASE_TESTSDIR / "files/store/")
+    keyids = rjce.file_encrypted_for((BASE_TESTSDIR / "files/double_recipient.asc").as_posix())
     assert keyids == ["1CF980B8E69E112A", "5A7A1560D46ED4F6"]
-    with open("tests/files/double_recipient.asc", "rb") as fobj:
+    with open(BASE_TESTSDIR / "files/double_recipient.asc", "rb") as fobj:
         data = fobj.read()
     keyids = rjce.bytes_encrypted_for(data)
     assert keyids == ["1CF980B8E69E112A", "5A7A1560D46ED4F6"]
 
 
-@vcr.use_cassette("tests/files/test_fetch_key_by_fingerprint.yml")
+@vcr.use_cassette((BASE_TESTSDIR / "files/test_fetch_key_by_fingerprint.yml").as_posix())
 def test_fetch_key_by_fingerprint():
     tempdir = tempfile.TemporaryDirectory()
     ks = jce.KeyStore(tempdir.name)
@@ -546,7 +547,7 @@ def test_fetch_key_by_fingerprint():
     assert uid["name"] == "Tor Browser Developers"
 
 
-@vcr.use_cassette("tests/files/test_fetch_nonexistingkey_by_fingerprint.yml")
+@vcr.use_cassette((BASE_TESTSDIR / "files/test_fetch_nonexistingkey_by_fingerprint.yml").as_posix())
 def test_fetch_nonexistingkey_by_fingerprint():
     tempdir = tempfile.TemporaryDirectory()
     ks = jce.KeyStore(tempdir.name)
@@ -554,7 +555,7 @@ def test_fetch_nonexistingkey_by_fingerprint():
         key = ks.fetch_key_by_fingerprint("EF6E286DDA85EA2A4BA7DE684E2C6E8793298291")
 
 
-@vcr.use_cassette("tests/files/test_fetch_key_by_email.yml")
+@vcr.use_cassette((BASE_TESTSDIR / "files/test_fetch_key_by_email.yml").as_posix())
 def test_fetch_key_by_email():
     tempdir = tempfile.TemporaryDirectory()
     ks = jce.KeyStore(tempdir.name)
@@ -565,7 +566,7 @@ def test_fetch_key_by_email():
     assert key.fingerprint == "2871635BE3B4E5C04F02B848C353BFE051D06C33"
 
 
-@vcr.use_cassette("tests/files/test_fetch_nonexistingkey_by_email.yml")
+@vcr.use_cassette((BASE_TESTSDIR / "files/test_fetch_nonexistingkey_by_email.yml").as_posix())
 def test_fetch_nonexistingkey_by_email():
     tempdir = tempfile.TemporaryDirectory()
     ks = jce.KeyStore(tempdir.name)

--- a/tests/test_parse_cert.py
+++ b/tests/test_parse_cert.py
@@ -2,6 +2,8 @@ import datetime
 
 import johnnycanencrypt.johnnycanencrypt as rustjce
 
+from tests.conftest import BASE_TESTSDIR
+
 
 def test_parse_cert_file():
     """Tests the rust implementation of the pgp key.
@@ -12,7 +14,7 @@ def test_parse_cert_file():
     etime = datetime.datetime(2020, 10, 16, 20, 53, 47)
     ctime = datetime.datetime(2017, 10, 17, 20, 53, 47)
     # First let us check from the file
-    keypath = "tests/files/store/pgp_keys.asc"
+    keypath = BASE_TESTSDIR / "files/store/pgp_keys.asc"
     (
         uids,
         fingerprint,
@@ -20,7 +22,7 @@ def test_parse_cert_file():
         expirationtime,
         creationtime,
         othervalues,
-    ) = rustjce.parse_cert_file(keypath)
+    ) = rustjce.parse_cert_file(keypath.as_posix())
     assert etime.date() == expirationtime.date()
     assert ctime.date() == creationtime.date()
 
@@ -34,7 +36,7 @@ def test_parse_cert_bytes():
     etime = datetime.datetime(2020, 10, 16, 20, 53, 47)
     ctime = datetime.datetime(2017, 10, 17, 20, 53, 47)
     # First let us read from the file
-    keypath = "tests/files/store/pgp_keys.asc"
+    keypath = BASE_TESTSDIR / "files/store/pgp_keys.asc"
     with open(keypath, "rb") as fobj:
         data = fobj.read()
 
@@ -58,11 +60,11 @@ def test_merge_certs():
     # These two are known values from kushal
     ctime = datetime.datetime(2017, 10, 17, 20, 53, 47)
     # First let us read from the file
-    keypath = "tests/files/store/pgp_keys.asc"
+    keypath = BASE_TESTSDIR / "files/store/pgp_keys.asc"
     with open(keypath, "rb") as fobj:
         data = fobj.read()
 
-    keypath = "tests/files/store/kushal_updated_key.asc"
+    keypath = BASE_TESTSDIR / "files/store/kushal_updated_key.asc"
     with open(keypath, "rb") as fobj:
         newdata = fobj.read()
 

--- a/tests/test_sign_verify_bytes.py
+++ b/tests/test_sign_verify_bytes.py
@@ -2,33 +2,34 @@ import pytest
 
 import johnnycanencrypt.johnnycanencrypt as jce
 
+from .conftest import BASE_TESTSDIR
 from .utils import _get_cert_data
 
 DATA = "Kushal loves 🦀"
 
 
 def test_sign():
-    j = jce.Johnny(_get_cert_data("tests/files/secret.asc"))
+    j = jce.Johnny(_get_cert_data(BASE_TESTSDIR / "files/secret.asc"))
     signature = j.sign_bytes_detached(DATA.encode("utf-8"), "redhat")
     assert signature
 
 
 def test_verify_bytes():
-    j = jce.Johnny(_get_cert_data("tests/files/secret.asc"))
+    j = jce.Johnny(_get_cert_data(BASE_TESTSDIR / "files/secret.asc"))
     signature = j.sign_bytes_detached(DATA.encode("utf-8"), "redhat")
-    jp = jce.Johnny(_get_cert_data("tests/files/public.asc"))
+    jp = jce.Johnny(_get_cert_data(BASE_TESTSDIR / "files/public.asc"))
     assert jp.verify_bytes(DATA.encode("utf-8"), signature.encode("utf-8"))
 
 
 def test_verify_bytes_must_fail():
-    j = jce.Johnny(_get_cert_data("tests/files/secret.asc"))
+    j = jce.Johnny(_get_cert_data(BASE_TESTSDIR / "files/secret.asc"))
     signature = j.sign_bytes_detached(DATA.encode("utf-8"), "redhat")
-    jp = jce.Johnny(_get_cert_data("tests/files/public.asc"))
+    jp = jce.Johnny(_get_cert_data(BASE_TESTSDIR / "files/public.asc"))
     data2 = DATA + " "
     assert not jp.verify_bytes(data2.encode("utf-8"), signature.encode("utf-8"))
 
 
 def test_sign_fail():
-    j = jce.Johnny(_get_cert_data("tests/files/public.asc"))
+    j = jce.Johnny(_get_cert_data(BASE_TESTSDIR / "files/public.asc"))
     with pytest.raises(jce.CryptoError):
         signature = j.sign_bytes_detached(DATA.encode("utf-8"), "redhat")


### PR DESCRIPTION
I couldnt run straight in pycharm the tests, because it sets the cwd to the tests directory by default and realized all paths are hardcoded, 
this PR just sets the path irrelative to the cwd,
As i'm using `Path` I had sometimes to use the `.as_posix()` method to get strings