### PR TITLE
Use pytest fixtures for temporary files and directories

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,15 +1,4 @@
 from pathlib import Path
 
-import pytest
-
-from .utils import clean_outputfiles
-
 BASE_TESTSDIR = Path(__file__).parent
 
-
-@pytest.fixture()
-def encrypt_decrypt_file():
-    inputfile = BASE_TESTSDIR / "files/text.txt"
-    output = "/tmp/text-encrypted.pgp"
-    decrypted_output = "/tmp/text.txt"
-    clean_outputfiles(output, decrypted_output)

--- a/tests/test_keystore.py
+++ b/tests/test_keystore.py
@@ -22,9 +22,11 @@ def test_nonexisting_keystore_path():
     with pytest.raises(OSError):
         ks = jce.KeyStore(BASE_TESTSDIR / "files2/")
 
-def test_str():
-    ks = jce.KeyStore("/tmp")
-    assert str(ks) == "<KeyStore dbpath=/tmp/jce.db>"
+
+def test_str(tmp_path):
+    ks = jce.KeyStore(tmp_path)
+    assert str(ks) == f"<KeyStore dbpath={tmp_path.as_posix()}/jce.db>"
+
 
 def test_no_such_key():
     with pytest.raises(jce.KeyNotFoundError):

--- a/tests/test_keystore.py
+++ b/tests/test_keystore.py
@@ -1,28 +1,17 @@
 import datetime
-import os
 import shutil
-import tempfile
 import sqlite3
 
 import pytest
 import vcr
-from pprint import pprint
 
 import johnnycanencrypt as jce
 import johnnycanencrypt.johnnycanencrypt as rjce
 
 from .conftest import BASE_TESTSDIR
-from .utils import clean_outputfiles, verify_files
+from .utils import verify_files
 
 DATA = "Kushal loves 🦀"
-
-
-def setup_module(module):
-    module.tmpdirname = tempfile.TemporaryDirectory()
-
-
-def teardown_module(module):
-    del module.tmpdirname
 
 
 def test_correct_keystore_path():
@@ -55,13 +44,13 @@ def test_create_primary_key_with_encryption():
     assert newkey.can_primary_sign == True
 
 
-def test_keystore_lifecycle():
+def test_keystore_lifecycle(tmp_path):
     # Before anything let us first delete if any existing db
     pathname = os.path.join(tmpdirname.name, "jce.db")
     if os.path.exists(pathname):
         os.remove(pathname)
     # Now create a fresh db
-    ks = jce.KeyStore(tmpdirname.name)
+    ks = jce.KeyStore(tmp_path.as_posix())
     newkey = ks.create_key("redhat", "test key1 <email@example.com>", jce.Cipher.RSA4k)
     # the default key must be of secret
     assert newkey.keytype == jce.KeyType.SECRET
@@ -94,9 +83,9 @@ def test_keystore_lifecycle():
     assert key_via_fingerprint == keys_via_names[0]
 
 
-def test_keystore_contains_key():
+def test_keystore_contains_key(tmp_path):
     "verifies __contains__ method for keystore"
-    ks = jce.KeyStore(tmpdirname.name)
+    ks = jce.KeyStore(tmp_path.as_posix())
     keypath = BASE_TESTSDIR / "files/store/secret.asc"
     k = ks.import_key(keypath.as_posix())
     _, fingerprint, keytype, exp, ctime, othervalues = jce.parse_cert_file(
@@ -137,17 +126,15 @@ def test_keystore_key_uids():
     assert "mail@kushaldas.in" == key.uids[-1]["email"]
 
 
-def test_key_password_change():
-    tempdir = tempfile.TemporaryDirectory()
-    ks = jce.KeyStore(tempdir.name)
+def test_key_password_change(tmp_path):
+    ks = jce.KeyStore(tmp_path.as_posix())
     k = ks.import_key((BASE_TESTSDIR / "files/store/secret.asc").as_posix())
     k2 = ks.update_password(k, "redhat", "byebye")
     data = ks.sign_detached(k2, b"hello", "byebye")
 
 
-def test_key_deletion():
-    tempdir = tempfile.TemporaryDirectory()
-    ks = jce.KeyStore(tempdir.name)
+def test_key_deletion(tmp_path):
+    ks = jce.KeyStore(tmp_path.as_posix())
     ks.import_key((BASE_TESTSDIR / "files/store/public.asc").as_posix())
     k = ks.import_key((BASE_TESTSDIR / "files/store/pgp_keys.asc").as_posix())
     ks.import_key((BASE_TESTSDIR / "files/store/hellopublic.asc").as_posix())
@@ -175,10 +162,9 @@ def test_key_equality():
     assert key.fingerprint == "F51C310E02DC1B7771E176D8A1C5C364EB5B9A20"
 
 
-def test_ks_update_expiry_time_for_subkeys():
+def test_ks_update_expiry_time_for_subkeys(tmp_path):
     "Updates expiry time for a given subkey"
-    tempdir = tempfile.TemporaryDirectory()
-    ks = jce.KeyStore(tempdir.name)
+    ks = jce.KeyStore(tmp_path.as_posix())
     ks.import_key((BASE_TESTSDIR / "files/store/hellosecret.asc").as_posix())
     ks.import_key((BASE_TESTSDIR / "files/store/secret.asc").as_posix())
 
@@ -229,12 +215,12 @@ def test_ks_encrypt_decrypt_bytes_multiple_recipients():
     assert DATA == decrypted_text
 
 
-def test_ks_encrypt_decrypt_bytes_to_file():
+def test_ks_encrypt_decrypt_bytes_to_file(tmp_path):
     "Encrypts and decrypt some bytes"
-    outputfile = os.path.join(tmpdirname.name, "encrypted.asc")
+    outputfile = tmp_path / "encrypted.asc"
     ks = jce.KeyStore(BASE_TESTSDIR / "files/store")
     secret_key = ks.get_key("F51C310E02DC1B7771E176D8A1C5C364EB5B9A20")
-    assert ks.encrypt(secret_key, DATA, outputfile=outputfile)
+    assert ks.encrypt(secret_key, DATA, outputfile=outputfile.as_posix())
     with open(outputfile, "rb") as fobj:
         encrypted = fobj.read()
     secret_key = ks.get_key("F51C310E02DC1B7771E176D8A1C5C364EB5B9A20")
@@ -244,13 +230,13 @@ def test_ks_encrypt_decrypt_bytes_to_file():
     assert DATA == decrypted_text
 
 
-def test_ks_encrypt_decrypt_bytes_to_file_multiple_recipients():
+def test_ks_encrypt_decrypt_bytes_to_file_multiple_recipients(tmp_path):
     "Encrypts and decrypt some bytes"
-    outputfile = os.path.join(tmpdirname.name, "encrypted.asc")
+    outputfile = tmp_path / "encrypted.asc"
     ks = jce.KeyStore(BASE_TESTSDIR / "files/store")
     key1 = ks.get_key("F51C310E02DC1B7771E176D8A1C5C364EB5B9A20")
     key2 = ks.get_key("F4F388BBB194925AE301F844C52B42177857DD79")
-    assert ks.encrypt([key1, key2], DATA, outputfile=outputfile)
+    assert ks.encrypt([key1, key2], DATA, outputfile=outputfile.as_posix())
     with open(outputfile, "rb") as fobj:
         encrypted = fobj.read()
     secret_key = ks.get_key("F51C310E02DC1B7771E176D8A1C5C364EB5B9A20")
@@ -324,16 +310,15 @@ def test_ks_sign_data_fails():
     assert not ks.verify(key, "hello2", signed)
 
 
-def test_ks_sign_verify_file_detached():
+def test_ks_sign_verify_file_detached(tmp_path):
     inputfile = BASE_TESTSDIR / "files/text.txt"
-    tempdir = tempfile.TemporaryDirectory()
-    shutil.copy(inputfile, tempdir.name)
+    shutil.copy(inputfile, tmp_path.as_posix())
     ks = jce.KeyStore(BASE_TESTSDIR / "files/store")
     key = "F51C310E02DC1B7771E176D8A1C5C364EB5B9A20"
-    file_to_be_signed = os.path.join(tempdir.name, "text.txt")
-    signed = ks.sign_file_detached(key, file_to_be_signed, "redhat", write=True)
+    file_to_be_signed = tmp_path / "text.txt"
+    signed = ks.sign_file_detached(key, file_to_be_signed.as_posix(), "redhat", write=True)
     assert signed.startswith("-----BEGIN PGP SIGNATURE-----\n")
-    assert ks.verify_file_detached(key, file_to_be_signed, file_to_be_signed + ".asc")
+    assert ks.verify_file_detached(key, file_to_be_signed.as_posix(), file_to_be_signed.as_posix() + ".asc")
 
 
 def test_ks_userid_signing():
@@ -373,17 +358,16 @@ def test_ks_userid_signing():
             assert len(uid["certifications"]) == 0
 
 
-def test_ks_creation_expiration_time():
+def test_ks_creation_expiration_time(tmp_path):
     """
     Tests via Kushal's key and a new key
     """
     # These two are known values from kushal
     etime = datetime.datetime(2020, 10, 16, 20, 53, 47)
     ctime = datetime.datetime(2017, 10, 17, 20, 53, 47)
-    tmpdir = tempfile.TemporaryDirectory()
     # First let us check from the file
     keypath = BASE_TESTSDIR / "files/store/pgp_keys.asc"
-    ks = jce.KeyStore(tmpdir.name)
+    ks = jce.KeyStore(tmp_path.as_posix())
     k = ks.import_key(keypath.as_posix())
     assert etime.date() == k.expirationtime.date()
     assert ctime.date() == k.creationtime.date()
@@ -450,10 +434,9 @@ def test_get_pub_key():
     assert pub_key.startswith("-----BEGIN PGP PUBLIC KEY BLOCK-----")
 
 
-def test_add_userid():
+def test_add_userid(tmp_path):
     """Verifies that we can add uid to a cert"""
-    tempdir = tempfile.TemporaryDirectory()
-    ks = jce.KeyStore(tempdir.name)
+    ks = jce.KeyStore(tmp_path.as_posix())
     key = ks.import_key((BASE_TESTSDIR / "files/store/secret.asc").as_posix())
     # check that there is only one userid
     assert len(key.uids) == 1
@@ -466,10 +449,9 @@ def test_add_userid():
     assert key2.keytype == jce.KeyType.SECRET
 
 
-def test_add_and_revoke_userid():
+def test_add_and_revoke_userid(tmp_path):
     """Verifies that we can add uid to a cert"""
-    tempdir = tempfile.TemporaryDirectory()
-    ks = jce.KeyStore(tempdir.name)
+    ks = jce.KeyStore(tmp_path.as_posix())
     key = ks.import_key((BASE_TESTSDIR / "files/store/secret.asc").as_posix())
     # check that there is only one userid
     assert len(key.uids) == 1
@@ -497,10 +479,9 @@ def test_add_and_revoke_userid():
             assert uid["revoked"] == False
 
 
-def test_add_userid_fails_for_public():
+def test_add_userid_fails_for_public(tmp_path):
     """Verifies that adding uid to a public key fails"""
-    tempdir = tempfile.TemporaryDirectory()
-    ks = jce.KeyStore(tempdir.name)
+    ks = jce.KeyStore(tmp_path.as_posix())
     key = ks.import_key((BASE_TESTSDIR / "files/store/public.asc").as_posix())
     # verify that the key is a secret
     assert len(key.uids) == 1
@@ -528,25 +509,22 @@ def test_update_subkey_expiry_time():
             assert date.date() == tomorrow
 
 
-def test_same_key_import_error():
-    tempdir = tempfile.TemporaryDirectory()
-    ks = jce.KeyStore(tempdir.name)
+def test_same_key_import_error(tmp_path):
+    ks = jce.KeyStore(tmp_path.as_posix())
     ks.import_key((BASE_TESTSDIR / "files/store/public.asc").as_posix())
     with pytest.raises(jce.CryptoError):
         ks.import_key((BASE_TESTSDIR / "files/store/public.asc").as_posix())
 
 
-def test_key_without_uid():
-    tempdir = tempfile.TemporaryDirectory()
-    ks = jce.KeyStore(tempdir.name)
+def test_key_without_uid(tmp_path):
+    ks = jce.KeyStore(tmp_path.as_posix())
     k = ks.create_key("redhat")
     uids, fp, secret, et, ct, othervalues = jce.parse_cert_bytes(k.keyvalue)
     assert len(uids) == 0
 
 
-def test_key_with_multiple_uids():
-    tempdir = tempfile.TemporaryDirectory()
-    ks = jce.KeyStore(tempdir.name)
+def test_key_with_multiple_uids(tmp_path):
+    ks = jce.KeyStore(tmp_path.as_posix())
     uids = [
         "Kushal Das <kushaldas@gmail.com>",
         "kushal@freedom.press",
@@ -557,13 +535,11 @@ def test_key_with_multiple_uids():
     assert len(uids) == 3
 
 
-def test_ks_upgrade():
+def test_ks_upgrade(tmp_path):
     "tests db upgrade from an old db"
-    tempdir = tempfile.TemporaryDirectory()
-    shutil.copy(
-        BASE_TESTSDIR / "files/store/oldjce.db", os.path.join(tempdir.name, "jce.db")
-    )
-    ks = jce.KeyStore(tempdir.name)
+    shutil.copy(BASE_TESTSDIR / "files/store/oldjce.db",  tmp_path / "jce.db")
+
+    ks = jce.KeyStore(tmp_path.as_posix())
     con = sqlite3.connect(ks.dbpath)
     con.row_factory = sqlite3.Row
     # First we will check if this db schema is old or not
@@ -576,18 +552,14 @@ def test_ks_upgrade():
     # TODO: Now verify the keys inside of the new db, in full.
 
 
-def test_ks_upgrade_failure():
+def test_ks_upgrade_failure(tmp_path):
     "tests db upgrade failure from an old db because of existing file"
-    tempdir = tempfile.TemporaryDirectory()
+    shutil.copy(BASE_TESTSDIR / "files/store/oldjce.db", tmp_path / "jce.db")
     shutil.copy(
-        BASE_TESTSDIR / "files/store/oldjce.db", os.path.join(tempdir.name, "jce.db")
-    )
-    shutil.copy(
-        BASE_TESTSDIR / "files/store/oldjce.db",
-        os.path.join(tempdir.name, "jce_upgrade.db"),
+        BASE_TESTSDIR / "files/store/oldjce.db", tmp_path / "jce_upgrade.db"
     )
     with pytest.raises(RuntimeError):
-        ks = jce.KeyStore(tempdir.name)
+        ks = jce.KeyStore(tmp_path.as_posix())
 
 
 def test_get_encrypted_for():
@@ -603,9 +575,8 @@ def test_get_encrypted_for():
 
 @vcr.use_cassette(
     (BASE_TESTSDIR / "files/test_fetch_key_by_fingerprint.yml").as_posix())
-def test_fetch_key_by_fingerprint():
-    tempdir = tempfile.TemporaryDirectory()
-    ks = jce.KeyStore(tempdir.name)
+def test_fetch_key_by_fingerprint(tmp_path):
+    ks = jce.KeyStore(tmp_path.as_posix())
     key = ks.fetch_key_by_fingerprint("EF6E286DDA85EA2A4BA7DE684E2C6E8793298290")
     assert len(key.uids) == 1
     uid = key.uids[0]
@@ -615,17 +586,15 @@ def test_fetch_key_by_fingerprint():
 
 @vcr.use_cassette(
     (BASE_TESTSDIR / "files/test_fetch_nonexistingkey_by_fingerprint.yml").as_posix())
-def test_fetch_nonexistingkey_by_fingerprint():
-    tempdir = tempfile.TemporaryDirectory()
-    ks = jce.KeyStore(tempdir.name)
+def test_fetch_nonexistingkey_by_fingerprint(tmp_path):
+    ks = jce.KeyStore(tmp_path.as_posix())
     with pytest.raises(jce.KeyNotFoundError):
         key = ks.fetch_key_by_fingerprint("EF6E286DDA85EA2A4BA7DE684E2C6E8793298291")
 
 
 @vcr.use_cassette((BASE_TESTSDIR / "files/test_fetch_key_by_email.yml").as_posix())
-def test_fetch_key_by_email():
-    tempdir = tempfile.TemporaryDirectory()
-    ks = jce.KeyStore(tempdir.name)
+def test_fetch_key_by_email(tmp_path):
+    ks = jce.KeyStore(tmp_path.as_posix())
     key = ks.fetch_key_by_email("anwesha.srkr@gmail.com")
     assert len(key.uids) == 2
     uid = key.uids[0]
@@ -635,8 +604,7 @@ def test_fetch_key_by_email():
 
 @vcr.use_cassette(
     (BASE_TESTSDIR / "files/test_fetch_nonexistingkey_by_email.yml").as_posix())
-def test_fetch_nonexistingkey_by_email():
-    tempdir = tempfile.TemporaryDirectory()
-    ks = jce.KeyStore(tempdir.name)
+def test_fetch_nonexistingkey_by_email(tmp_path):
+    ks = jce.KeyStore(tmp_path.as_posix())
     with pytest.raises(jce.KeyNotFoundError):
         ks.fetch_key_by_email("doesnotexists@kushaldas.in")

--- a/tests/test_keystore.py
+++ b/tests/test_keystore.py
@@ -246,51 +246,51 @@ def test_ks_encrypt_decrypt_bytes_to_file_multiple_recipients(tmp_path):
     assert DATA == decrypted_text
 
 
-def test_ks_encrypt_decrypt_file(encrypt_decrypt_file):
+def test_ks_encrypt_decrypt_file(tmp_path):
     "Encrypts and decrypt some bytes"
     inputfile = BASE_TESTSDIR / "files/text.txt"
-    output = "/tmp/text-encrypted.pgp"
-    decrypted_output = "/tmp/text.txt"
+    output = tmp_path / "text-encrypted.pgp"
+    decrypted_output = tmp_path / "text.txt"
 
     ks = jce.KeyStore(BASE_TESTSDIR / "files/store")
     public_key = ks.get_key("F51C310E02DC1B7771E176D8A1C5C364EB5B9A20")
-    assert ks.encrypt_file(public_key, inputfile.as_posix(), output)
+    assert ks.encrypt_file(public_key, inputfile.as_posix(), output.as_posix())
     secret_key = ks.get_key("F51C310E02DC1B7771E176D8A1C5C364EB5B9A20")
-    ks.decrypt_file(secret_key, output, decrypted_output, password="redhat")
+    ks.decrypt_file(secret_key, output.as_posix(), decrypted_output.as_posix(), password="redhat")
     verify_files(inputfile, decrypted_output)
 
 
-def test_ks_encrypt_decrypt_filehandler(encrypt_decrypt_file):
+def test_ks_encrypt_decrypt_filehandler(tmp_path):
     "Encrypts and decrypt some bytes"
     inputfile = BASE_TESTSDIR / "files/text.txt"
-    output = "/tmp/text-encrypted.pgp"
-    decrypted_output = "/tmp/text.txt"
+    output = tmp_path / "text-encrypted.pgp"
+    decrypted_output = tmp_path / "text.txt"
 
     ks = jce.KeyStore(BASE_TESTSDIR / "files/store")
     public_key = ks.get_key("F51C310E02DC1B7771E176D8A1C5C364EB5B9A20")
     with open(inputfile, "rb") as fobj:
-        assert ks.encrypt_file(public_key, fobj, output)
+        assert ks.encrypt_file(public_key, fobj, output.as_posix())
     secret_key = ks.get_key("F51C310E02DC1B7771E176D8A1C5C364EB5B9A20")
     with open(output, "rb") as fobj:
-        ks.decrypt_file(secret_key, fobj, decrypted_output, password="redhat")
+        ks.decrypt_file(secret_key, fobj, decrypted_output.as_posix(), password="redhat")
     verify_files(inputfile, decrypted_output)
 
 
-def test_ks_encrypt_decrypt_file_multiple_recipients(encrypt_decrypt_file):
+def test_ks_encrypt_decrypt_file_multiple_recipients(tmp_path):
     "Encrypts and decrypt some bytes"
     inputfile = BASE_TESTSDIR / "files/text.txt"
-    output = "/tmp/text-encrypted.pgp"
-    decrypted_output = "/tmp/text.txt"
+    output = tmp_path / "text-encrypted.pgp"
+    decrypted_output = tmp_path / "text.txt"
 
     ks = jce.KeyStore(BASE_TESTSDIR / "files/store")
     key1 = ks.get_key("F51C310E02DC1B7771E176D8A1C5C364EB5B9A20")
     key2 = ks.get_key("F4F388BBB194925AE301F844C52B42177857DD79")
-    encrypted = ks.encrypt_file([key1, key2], inputfile.as_posix(), output)
+    encrypted = ks.encrypt_file([key1, key2], inputfile.as_posix(), output.as_posix())
     secret_key1 = ks.get_key("F51C310E02DC1B7771E176D8A1C5C364EB5B9A20")
-    ks.decrypt_file(secret_key1, output, decrypted_output, password="redhat")
+    ks.decrypt_file(secret_key1, output.as_posix(), decrypted_output.as_posix(), password="redhat")
     verify_files(inputfile, decrypted_output)
     secret_key2 = ks.get_key("F4F388BBB194925AE301F844C52B42177857DD79")
-    ks.decrypt_file(secret_key2, output, decrypted_output, password="redhat")
+    ks.decrypt_file(secret_key2, output.as_posix(), decrypted_output.as_posix(), password="redhat")
     verify_files(inputfile, decrypted_output)
 
 

--- a/tests/test_keystore.py
+++ b/tests/test_keystore.py
@@ -593,8 +593,7 @@ def test_ks_upgrade_failure():
 def test_get_encrypted_for():
     ks = jce.KeyStore(BASE_TESTSDIR / "files/store/")
     keyids = rjce.file_encrypted_for(
-        (BASE_TESTSDIR / "files/double_recipient.asc").as_posix()
-    )
+        (BASE_TESTSDIR / "files/double_recipient.asc").as_posix())
     assert keyids == ["1CF980B8E69E112A", "5A7A1560D46ED4F6"]
     with open(BASE_TESTSDIR / "files/double_recipient.asc", "rb") as fobj:
         data = fobj.read()
@@ -603,8 +602,7 @@ def test_get_encrypted_for():
 
 
 @vcr.use_cassette(
-    (BASE_TESTSDIR / "files/test_fetch_key_by_fingerprint.yml").as_posix()
-)
+    (BASE_TESTSDIR / "files/test_fetch_key_by_fingerprint.yml").as_posix())
 def test_fetch_key_by_fingerprint():
     tempdir = tempfile.TemporaryDirectory()
     ks = jce.KeyStore(tempdir.name)
@@ -616,8 +614,7 @@ def test_fetch_key_by_fingerprint():
 
 
 @vcr.use_cassette(
-    (BASE_TESTSDIR / "files/test_fetch_nonexistingkey_by_fingerprint.yml").as_posix()
-)
+    (BASE_TESTSDIR / "files/test_fetch_nonexistingkey_by_fingerprint.yml").as_posix())
 def test_fetch_nonexistingkey_by_fingerprint():
     tempdir = tempfile.TemporaryDirectory()
     ks = jce.KeyStore(tempdir.name)
@@ -637,8 +634,7 @@ def test_fetch_key_by_email():
 
 
 @vcr.use_cassette(
-    (BASE_TESTSDIR / "files/test_fetch_nonexistingkey_by_email.yml").as_posix()
-)
+    (BASE_TESTSDIR / "files/test_fetch_nonexistingkey_by_email.yml").as_posix())
 def test_fetch_nonexistingkey_by_email():
     tempdir = tempfile.TemporaryDirectory()
     ks = jce.KeyStore(tempdir.name)

--- a/tests/test_keystore.py
+++ b/tests/test_keystore.py
@@ -32,8 +32,8 @@ def test_no_such_key():
         key = ks.get_key("A4F388BBB194925AE301F844C52B42177857DD79")
 
 
-def test_create_primary_key_with_encryption():
-    ks = jce.KeyStore(tmpdirname.name)
+def test_create_primary_key_with_encryption(tmp_path):
+    ks = jce.KeyStore(tmp_path.as_posix())
     newkey = ks.create_key(
         "redhat",
         "test key42 <42@example.com>",
@@ -45,10 +45,6 @@ def test_create_primary_key_with_encryption():
 
 
 def test_keystore_lifecycle(tmp_path):
-    # Before anything let us first delete if any existing db
-    pathname = os.path.join(tmpdirname.name, "jce.db")
-    if os.path.exists(pathname):
-        os.remove(pathname)
     # Now create a fresh db
     ks = jce.KeyStore(tmp_path.as_posix())
     newkey = ks.create_key("redhat", "test key1 <email@example.com>", jce.Cipher.RSA4k)
@@ -321,12 +317,9 @@ def test_ks_sign_verify_file_detached(tmp_path):
     assert ks.verify_file_detached(key, file_to_be_signed.as_posix(), file_to_be_signed.as_posix() + ".asc")
 
 
-def test_ks_userid_signing():
-    pathname = os.path.join(tmpdirname.name, "jce.db")
-    if os.path.exists(pathname):
-        os.remove(pathname)
+def test_ks_userid_signing(tmp_path):
     # Now create a fresh db
-    ks = jce.KeyStore(tmpdirname.name)
+    ks = jce.KeyStore(tmp_path.as_posix())
     k = ks.import_key((BASE_TESTSDIR / "files/store/pgp_keys.asc").as_posix())
     t2 = ks.import_key((BASE_TESTSDIR / "files/store/secret.asc").as_posix())
 

--- a/tests/test_sign_verify_bytes.py
+++ b/tests/test_sign_verify_bytes.py
@@ -1,5 +1,4 @@
 import os
-import tempfile
 
 import pytest
 
@@ -38,11 +37,10 @@ def test_sign_cleartext():
     assert jp.verify_bytes(signed_data.encode("utf-8"))
 
 
-def test_sign_verify_file_cleartext():
+def test_sign_verify_file_cleartext(tmp_path):
     "This will sign a file in cleartext"
     j = jce.Johnny(_get_cert_data(BASE_TESTSDIR / "files/secret.asc"))
-    tempdir = tempfile.TemporaryDirectory()
-    output = os.path.join(tempdir.name, "sign.asc")
+    output = (tmp_path / "sign.asc").as_posix()
     j.sign_file(
         (BASE_TESTSDIR / "files/text.txt").as_posix().encode(),
         output.encode("utf-8"),
@@ -59,12 +57,10 @@ def test_sign_verify_file_cleartext():
     assert jp.verify_file(output.encode("utf-8"))
 
 
-def test_sign_verify_file():
+def test_sign_verify_file(tmp_path):
     "This will sign a file as a PGP message"
     j = jce.Johnny(_get_cert_data(BASE_TESTSDIR / "files/secret.asc"))
-    tempdir = tempfile.TemporaryDirectory()
-    # output = os.path.join(tempdir.name, "sign.asc")
-    output = "/tmp/sign.asc"
+    output = (tmp_path / "sign.asc").as_posix()
     j.sign_file(
         (BASE_TESTSDIR / "files/text.txt").as_posix().encode(),
         output.encode("utf-8"),
@@ -89,14 +85,12 @@ def test_sign_from_gpg_verify_file():
     assert jp.verify_file(str(BASE_TESTSDIR / "files/msg.txt.asc").encode("utf-8"))
 
 
-def test_verify_signed_file():
+def test_verify_signed_file(tmp_path):
     "This will verify a signed message from gpg and extract"
     jp = jce.Johnny(
         _get_cert_data(BASE_TESTSDIR / "files/store/kushal_updated_key.asc")
     )
-
-    tempdir = tempfile.TemporaryDirectory()
-    output = os.path.join(tempdir.name, "result.txt")
+    output = (tmp_path / "result.txt").as_posix()
     assert jp.verify_and_extract_file(
         str(BASE_TESTSDIR / "files/msg.txt.asc").encode("utf-8"), output.encode("utf-8")
     )

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,18 +1,7 @@
-import os
-
-
 def _get_cert_data(filepath):
     "Returns the filepath content as bytes"
     with open(filepath, "rb") as fobj:
         return fobj.read()
-
-
-def clean_outputfiles(output, decrypted_output):
-    # Remove any existing test files
-    if os.path.exists(output):
-        os.remove(output)
-    if os.path.exists(decrypted_output):
-        os.remove(decrypted_output)
 
 
 def verify_files(inputfile, decrypted_output):


### PR DESCRIPTION
This build on previous PR and uses the built-in pytest [fixture](https://docs.pytest.org/en/7.1.x/how-to/tmp_path.html) `tmp_path` instead of the xunit_style setup_module

This way your /tmp folder is not cluttered anymore with all the files created, and you're not forced into your tests to think about deleting created files.